### PR TITLE
Fix CSS syntax by removing trailing semicolon from the --color-primar…

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,7 @@
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
+  --color-primary-foreground: var(--primary-foreground)
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);


### PR DESCRIPTION
…y-foreground variable declaration.